### PR TITLE
[Bug] Hospital table 생성 오류 수정

### DIFF
--- a/src/main/java/com/smiley/smileybackend/domain/Hospital.java
+++ b/src/main/java/com/smiley/smileybackend/domain/Hospital.java
@@ -53,7 +53,7 @@ public class Hospital {
     private String dutyEryn;
 
     /*비고*/
-    @Column(length = 25000)
+    @Column(length = 600)
     private String dutyEtc;
 
     /*기관설명상세*/


### PR DESCRIPTION
# ✒️ 관련 이슈번호
- Closed #107 

# 🔑 Key Changes>
- hospital table의 dutyEtc의 max length를 25000-> 600으로 수정 (사용하는 최대 길이가 514)
![image](https://github.com/DEU-Smiley/Smiley-BackEnd/assets/115801420/61180d96-d8f8-4f0e-8c57-31af72d4a495)

# 📢 To Reviewers
